### PR TITLE
Add documentation capability using quickhelp.

### DIFF
--- a/company-lsp.el
+++ b/company-lsp.el
@@ -251,6 +251,21 @@ Return a plist of (:incomplete :candidates) if cache for PREFIX
 exists. Otherwise return nil."
   (cdr (assoc prefix company-lsp--completion-cache)))
 
+(defun company-lsp--documentation (candidate)
+  "Get the documentation from the item in the CANDIDATE.
+
+The documentation can be either string or MarkupContent. This method
+will return markdown string if it is MarkupContent, original string
+otherwise. If the documentation is not present, it will return nil
+which company can handle."
+  (let* ((resolved-candidate (company-lsp--resolve-candidate candidate "documentation"))
+         (item (company-lsp--candidate-item resolved-candidate))
+         (documentation (gethash "documentation" item)))
+    (if
+        (hash-table-p documentation)  ;; If true, then the documentation is a MarkupContent. String otherwise.
+        (gethash "value" documentation)
+      documentation)))
+
 ;;;###autoload
 (defun company-lsp (command &optional arg &rest _)
   "Define a company backend for lsp-mode.
@@ -284,6 +299,7 @@ See the documentation of `company-backends' for COMMAND and ARG."
                     (and cache (plist-get cache :incomplete)))
                 (not company-lsp-cache-candidates)))
     (annotation (lsp--annotate arg))
+    (quickhelp-string (company-lsp--documentation arg))
     (match (length arg))
     (post-completion (company-lsp--post-completion arg))))
 


### PR DESCRIPTION
https://melpa.org/#/company-quickhelp can show documentation of a completion candidate while scrolling through the completion list. The documentation is already sent by language servers when sending completion candidates. This change wires the documentation from CompletionItem to the quickhelp-string backend parameter which company-quickhelp can use to show documentation.

Python screenshot:

![screen shot 2017-12-18 at 9 18 28 pm](https://user-images.githubusercontent.com/1002513/34141933-448d7854-e439-11e7-960f-a9b7a0545ad1.png)
