### PR TITLE
Fix re-triggering condition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ After installing company-lsp, simply add `company-lsp` to `company-backends`:
     asynchronously.
  * `company-lsp-enable-snippet`: Set it to non-nil if you want to enable snippet
     expansion on completion. Set it to nil to disable this feature.
+ * `company-lsp-enable-recompletion`: If set to non-nil, when company-lsp
+    finishes completion, it checks if the current point is before any completion
+    trigger characters. If yes, it re-triggers another completion request.
+
+    This is useful in cases such as `std` is completed as `std::` in C++."
     
 ## Defining completion snippet for a certain language
 


### PR DESCRIPTION
The current logic checks whether (point) changes before and after post
completion actions to determine if re-triggering completion is desired. However,
this logic is not robust enough. It incorrectly re-triggers completion when the
post-completion action adds import statements by Javacomp, or fixes the
duplicated `#` characters by cquery (see #21).

This change proposes comparing the suffix of the completion before and after
post-completion editing. I tested that it still works for the desired case
(`std::`) while not re-triggering completion for either the cquery include or
Javacomp auto-import case.