### PR TITLE
Fix caching for the auto mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,21 @@ After installing company-lsp, simply add `company-lsp` to `company-backends`:
 
 ## Customization
 
- * `company-lsp-cache-candidates`: Can be set to `'auto`, `t`, or `nil`. When
-    set to `'auto`, candidates will not be cached if the server returns
-    incomplete completion list. When set to `t`, company caches the completion
-    candidates and filters the candidates as completion progresses. If set to
-    `nil`, each incremental completion triggers a completion request to the
-    language server.
+ * `company-lsp-cache-candidates`: Can be set to `'auto`, `t`, or `nil`.
+
+    When set to `'auto`, company-lsp caches the completion. It sends
+    incremental completion requests to the server if and only if the
+    cached results are incomplete. The candidate list may not be
+    sorted or filtered as the server would for cached completion
+    results.
+
+    When set to `t`, company-mode caches the completion. It won't send
+    incremental completion requests to the server.
+
+    When set to `nil`, results are not cached at all. The candidates
+    are always sorted and filtered by the server. Use this option if
+    the server handles caching for incremental completion or
+    sorting/matching provided by the server is critical.
  * `company-lsp-async`: When set to non-nil, fetch completion candidates
     asynchronously.
  * `company-lsp-enable-snippet`: Set it to non-nil if you want to enable snippet

--- a/test/company-lsp-test.el
+++ b/test/company-lsp-test.el
@@ -126,3 +126,43 @@
         (puthash "detail" "(1, 2)" item)
         (expect (company-lsp--rust-completion-snippet item)
                 :to-be nil)))))
+
+(describe "Getting cache"
+  (it "Should return the cache item if prefix matches"
+    (let ((company-lsp--completion-cache nil)
+          (cache-item '(:incomplete nil ("foo" "bar"))))
+      (company-lsp--cache-put "prefix" cache-item)
+      (expect (company-lsp--cache-get "prefix")
+              :to-equal cache-item)))
+
+  (it "Should return the cache item of sub-prefix if it's complete"
+    (let ((cache-item '(:incomplete nil ("foo" "bar"))))
+      (setq company-lsp--completion-cache nil)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal nil)
+      (company-lsp--cache-put "" cache-item)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal cache-item)
+
+      (setq company-lsp--completion-cache nil)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal nil)
+      (company-lsp--cache-put "prefix" cache-item)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal cache-item)
+
+      (setq company-lsp--completion-cache nil)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal nil)
+      (company-lsp--cache-put "prefix123" cache-item)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal cache-item)))
+
+  (it "Should not return the cache item of sub-prefix if it's incomplete"
+    (let ((company-lsp--completion-cache nil)
+          (cache-item '(:incomplete t ("foo" "bar"))))
+      (company-lsp--cache-put "prefix" cache-item)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal nil))))
+
+


### PR DESCRIPTION
 - If the current prefix is not in the cache but a complete candidate list
   is found in one of its prefixes, update the cache for the prefix. This
   avoids unnecessary incremental completion requests.
 - If no cache is found, do not allow company to cache candidates.