### PR TITLE
Incremental cache should filter candidates.

### DIFF
--- a/test/company-lsp-test.el
+++ b/test/company-lsp-test.el
@@ -136,7 +136,7 @@
               :to-equal cache-item)))
 
   (it "Should return the cache item of sub-prefix if it's complete"
-    (let ((cache-item '(:incomplete nil ("foo" "bar"))))
+    (let ((cache-item (company-lsp--cache-item-new '("prefix1234" "prefix12345") nil)))
       (setq company-lsp--completion-cache nil)
       (expect (company-lsp--cache-get "prefix1234")
               :to-equal nil)
@@ -157,6 +157,15 @@
       (company-lsp--cache-put "prefix123" cache-item)
       (expect (company-lsp--cache-get "prefix1234")
               :to-equal cache-item)))
+
+  (it "Should filter cache items of sub-prefix"
+    (let ((cache-item (company-lsp--cache-item-new
+                       '("prefix" "prefix123" "prefix1234" "prefix12345")
+                       nil)))
+      (company-lsp--cache-put "prefix" cache-item)
+      (expect (company-lsp--cache-get "prefix1234")
+              :to-equal
+              (company-lsp--cache-item-new '("prefix1234" "prefix12345") nil))))
 
   (it "Should not return the cache item of sub-prefix if it's incomplete"
     (let ((company-lsp--completion-cache nil)


### PR DESCRIPTION
Now that we manage the cache on our own, company-mode is no longer responsible
for filtering cached candidates for incremental completion. The matching
experience is broken now: once cached, incremental completion doesn't filter out
any candidates.

Use `all-completions` as company-mode does now. In the future we want to allow
users to customize it to support better matching algorithms. We may want to
use `completion-all-complete` and adopt [company-flx](https://github.com/PythonNut/company-flx), but let's fix this first.