### PR TITLE
add support for doc-buffer

### DIFF
--- a/company-lsp.el
+++ b/company-lsp.el
@@ -409,6 +409,7 @@ See the documentation of `company-backends' for COMMAND and ARG."
     (no-cache (not (eq company-lsp-cache-candidates t)))
     (annotation (lsp--annotate arg))
     (quickhelp-string (company-lsp--documentation arg))
+    (doc-buffer (company-doc-buffer (company-lsp--documentation arg)))
     (match (length arg))
     (post-completion (company-lsp--post-completion arg))))
 


### PR DESCRIPTION
In addition to quickhelp, there is a company-built-in way to show documentation. This adds support for it.