### PR TITLE
Fix #46 Return nil as prefix when in string or comment

### DIFF
--- a/company-lsp.el
+++ b/company-lsp.el
@@ -400,6 +400,7 @@ See the documentation of `company-backends' for COMMAND and ARG."
     (prefix (and
              (bound-and-true-p lsp-mode)
              (lsp--capability "completionProvider")
+             (not (company-in-string-or-comment))
              (or (company-lsp--completion-prefix) 'stop)))
     (candidates
      ;; If the completion items in the response have textEdit action populated,


### PR DESCRIPTION
When point is in comment or a string, company-lsp should bail and give the next
backend a chance to try.

Reference implementation: https://github.com/proofit404/company-tern/blob/master/company-tern.el#L56