### PR TITLE
Use cl-incf instead of incf

### DIFF
--- a/company-lsp.el
+++ b/company-lsp.el
@@ -430,12 +430,12 @@ within CANDIDATE that matches the current prefix. See the
           (progn
             (when (not chunk-start)
               (setq chunk-start candidate-pos))
-            (incf prefix-pos)
-            (incf candidate-pos))
+            (cl-incf prefix-pos)
+            (cl-incf candidate-pos))
         (when chunk-start
           (push (cons chunk-start candidate-pos) chunks)
           (setq chunk-start nil))
-        (incf candidate-pos)))
+        (cl-incf candidate-pos)))
     (when chunk-start
       (push (cons chunk-start candidate-pos) chunks))
     (nreverse chunks)))


### PR DESCRIPTION
Plain `incr` would actually need `(require 'cl)`, which is deprecated. Use `cl-incf`
from `cl-lib` instead, which is already required.