### PR TITLE
Allow completion in strings and comments

### DIFF
--- a/company-lsp.el
+++ b/company-lsp.el
@@ -752,7 +752,9 @@ See the documentation of `company-backends' for COMMAND and ARG."
      (and
       (bound-and-true-p lsp-mode)
       (lsp--capability "completionProvider")
-      (not (company-in-string-or-comment))
+      (or (--some (lsp--client-completion-in-comments? (lsp--workspace-client it))
+                  (lsp-workspaces))
+          (not (company-in-string-or-comment)))
       (or (company-lsp--completion-prefix) 'stop)))
     (candidates
      ;; If the completion items in the response have textEdit action populated,


### PR DESCRIPTION
Some of the language servers do provide completion in strings and comments.