### PR TITLE
Do not use client-side filtering for clangd.

### DIFF
--- a/company-lsp.el
+++ b/company-lsp.el
@@ -66,6 +66,7 @@ Otherwise candidates are not filtered."
 
 (defcustom company-lsp-filter-candidates '((bingo . nil)
                                            (ccls . nil)
+                                           (clangd . nil)
                                            (cquery . nil)
                                            (javacomp . nil)
                                            (jdtls . nil)


### PR DESCRIPTION
Clangd supports server-side filtering.