### PR TITLE
Never cache the items in company-mode

### DIFF
--- a/company-lsp.el
+++ b/company-lsp.el
@@ -770,7 +770,7 @@ See the documentation of `company-backends' for COMMAND and ARG."
                              (company-lsp--candidates-async arg callback))))
          (company-lsp--candidates-sync arg)))
     (sorted t)
-    (no-cache (not (eq company-lsp-cache-candidates t)))
+    (no-cache t)
     (annotation (lsp--annotate arg))
     (quickhelp-string (company-lsp--documentation arg))
     (doc-buffer (company-doc-buffer (company-lsp--documentation arg)))


### PR DESCRIPTION
We should always use the company-lsp cache otherwise company-mode will keep
cache prefix->items which are not relevant to the current position.